### PR TITLE
fix: 랭킹 조회 인원 매개변수 추가

### DIFF
--- a/src/pages/Ranking/Ranking.tsx
+++ b/src/pages/Ranking/Ranking.tsx
@@ -11,11 +11,11 @@ const Ranking: React.FC = () => {
     const [userRankList, setUserRankList] = useState<RankInfo[]>([]);
     const [userTopThreeList, setUserTopThreeList] = useState<RankInfo[]>([]);
 
-    const getUserRankList = async () => {
+    const getUserRankList = async (count: number) => {
         try {
             const response: res<RankInfo[]> = await axiosRequest.requestAxios<
                 res<RankInfo[]>
-            >("get", "/users/rank", {});
+            >("get", `/users/rank/${count}`, {});
             setUserRankList(response.data);
             setUserTopThreeList(setTopThree(response.data));
         } catch (error) {
@@ -37,7 +37,7 @@ const Ranking: React.FC = () => {
     };
 
     useEffect(() => {
-        getUserRankList();
+        getUserRankList(2);
     }, []);
 
     return (


### PR DESCRIPTION
> 변경사항

- 랭킹 리스트 조회 시 지정된 count 값만큼 유저를 조회하도록 수정

> 변경사유

- 10명 고정 조회가 아닌 유동적으로 랭킹 리스트를 조회하기 위함