### PR TITLE
fix: Todo 페이지 빈 영역 클릭 시 입력 탭 닫힘 처리 (#130)

### DIFF
--- a/src/components/pages/Todo/TodoList/TodoItem/Todos/Todo/TodoForm/index.tsx
+++ b/src/components/pages/Todo/TodoList/TodoItem/Todos/Todo/TodoForm/index.tsx
@@ -99,6 +99,8 @@ export const TodoForm = ({
       if (!isSuccess) {
         return;
       }
+      // 신규 입력 완료 후에는 입력 폼을 닫아 UX를 일관되게 유지한다.
+      finishEdit?.();
     }
     await setTodos(selectedDate, selectedDate);
     reset({ content: "" });


### PR DESCRIPTION
### 📝 작업 개요
- Todo 페이지에서 신규 할 일 입력 후 빈 영역을 클릭해도 입력 탭이 닫히지 않던 문제를 수정했습니다.

### 🔧 주요 변경 사항
- src/components/pages/Todo/TodoList/TodoItem/Todos/Todo/TodoForm/index.tsx에서 신규 할 일 등록 성공 시 finishEdit 콜백을 호출하도록 변경했습니다.
- 기존 수정 모드와 동일하게 입력 완료 시 폼이 닫히도록 동작을 통일했습니다.

### 🎯 변경 목적
- 사용자가 할 일 입력을 마친 뒤 빈 영역 클릭 시 입력 탭이 자동으로 닫히는 기대 UX를 만족하기 위함입니다.

### 🧪 검증 방법
- npm run lint (기존 경고만 존재, 신규 에러 없음)
- npm run test
- npm run build
- 수동 검증: Todo 입력 후 빈 영역 클릭 시 입력 탭 닫힘 확인

### 📌 참고 사항
- lint 경고(13건)는 기존 코드베이스에 존재하던 항목이며, 이번 수정으로 인한 신규 경고는 없습니다.

Closes #130
